### PR TITLE
Add Dependabot Github Action

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    reviewers:
+      - "shinkansenfinance/engineering"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    versioning-strategy: widen
+
+    allow:
+      - dependency-type: "all"
+    schedule:
+      interval: "weekly"
+
+    groups:
+      python-deps:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 2
+    reviewers:
+      - "shinkansenfinance/engineering"


### PR DESCRIPTION
# Description

Adds dependabot config to repo. This setup will open pull requests on a regular schedule, making it easier to review and merge dependency updates in a controlled way.